### PR TITLE
docs: Fix automation workflows to match GitHub Projects v2

### DIFF
--- a/.github/PROJECT_AUTOMATION_SETUP.md
+++ b/.github/PROJECT_AUTOMATION_SETUP.md
@@ -20,47 +20,68 @@ These are the easiest to set up and handle most common scenarios.
 1. Go to your project: https://github.com/users/BenedictSmith/projects/2
 2. Click the `⋯` menu (top right) → **Settings**
 3. Click **Workflows** in the left sidebar
-4. Enable the following workflows:
+4. Enable the following recommended workflows:
 
-#### Workflow 1: Auto-add items
+#### Recommended Workflows to Enable
 
-- **Trigger:** Item added to project
-- **Action:** Set Status to "Todo"
-- **Purpose:** All new issues/PRs start in the backlog
+Based on actual GitHub Projects v2 workflows (as of 2025-11-28):
 
-#### Workflow 2: Item closed
+**Essential Workflows:**
 
-- **Trigger:** Item closed
-- **Action:** Set Status to "Done"
-- **Purpose:** Completed issues automatically move to Done
+1. **Auto-add to project**
+   - Automatically adds new issues/PRs to the project
 
-#### Workflow 3: Pull request merged
+2. **Item added to project**
+   - Sets initial status when item is added
+   - Configure to set Status → "Todo"
 
-- **Trigger:** Pull request merged
-- **Action:** Set Status to "Done"
-- **Purpose:** Merged PRs move to Done
+3. **Item closed**
+   - Updates status when issue/PR is closed
+   - Configure to set Status → "Done"
 
-#### Workflow 4: Pull request opened/reopened
+4. **Pull request merged**
+   - Updates status when PR is merged
+   - Configure to set Status → "Done"
 
-- **Trigger:** Pull request opened or reopened
-- **Action:** Set Status to "In Review"
-- **Purpose:** Active PRs move to In Review
+5. **Item reopened**
+   - Handles reopened issues
+   - Configure to set Status → "Todo"
 
-#### Workflow 5: Issue/PR assigned
+**Nice-to-Have Workflows:**
 
-- **Trigger:** Issue or pull request assigned
-- **Action:** Set Status to "In Progress"
-- **Condition:** Only if current status is "Todo" or "Ready"
-- **Purpose:** Self-assignment indicates work has started
+6. **Pull request linked to issue**
+   - Updates status when PR links to issue
+   - Configure to set Status → "In Review"
+
+7. **Code review approved**
+   - Updates when PR review is approved
+   - Optional: Set Status → "Ready to Merge"
+
+8. **Code changes requested**
+   - Updates when changes requested on PR
+   - Optional: Keep in "In Review" or move to "In Progress"
+
+9. **Auto-archive items**
+   - Archives old completed items after a period
+   - Keeps board clean
+
+10. **Auto-close issue**
+    - Optional: Auto-close issues after certain conditions
+
+11. **Auto-add sub-issues to project**
+    - Automatically adds sub-issues if using issue hierarchies
 
 ### Expected Behavior
 
-After setup, the project will automatically:
+After enabling these workflows, the project will automatically:
 
 - ✅ Add new issues to the project in "Todo" status
-- ✅ Move assigned issues to "In Progress"
-- ✅ Move PRs to "In Review" when opened
+- ✅ Move PRs to "In Review" when linked to issues
 - ✅ Move items to "Done" when closed or merged
+- ✅ Reopen items back to "Todo" when reopened
+- ✅ Archive old items to keep board clean
+
+**Note:** There is no built-in "Issue assigned → In Progress" workflow in GitHub Projects v2. You must manually move items to "In Progress" when starting work, or create a custom GitHub Action for this.
 
 ---
 

--- a/.github/PROJECT_BOARD_SETUP.md
+++ b/.github/PROJECT_BOARD_SETUP.md
@@ -85,25 +85,30 @@ Move to **📋 Backlog**:
 
 Configure these automations in the project settings (Settings → Workflows):
 
-1. **When issue closed** → Move to **✅ Done**
+1. **Auto-add to project**
+   - Automatically adds new issues/PRs to the project
+
+2. **Item added to project** → Set to **📋 Todo**
+   - Trigger: Item added to project
+   - Action: Set status to "Todo"
+
+3. **Item closed** → Move to **✅ Done**
    - Trigger: Item closed
    - Action: Set status to "Done"
 
-2. **When PR created** → Move linked issues to **👀 In Review**
-   - Trigger: Pull request opened
-   - Action: Set status to "In Review"
-
-3. **When PR merged** → Move linked issues to **✅ Done**
+4. **Pull request merged** → Move to **✅ Done**
    - Trigger: Pull request merged
    - Action: Set status to "Done"
 
-4. **When assigned** → Move to **🚧 In Progress** (if in Ready)
-   - Trigger: Issue assigned
-   - Action: Set status to "In Progress"
+5. **Pull request linked to issue** → Move to **👀 In Review**
+   - Trigger: Pull request linked to issue
+   - Action: Set status to "In Review"
 
-5. **Auto-add new items** → Add to **📋 Backlog**
-   - Trigger: Item added to project
+6. **Item reopened** → Move back to **📋 Todo**
+   - Trigger: Item reopened
    - Action: Set status to "Todo"
+
+**Note:** There is no built-in workflow for "Issue assigned → In Progress". Manually update status to "In Progress" when starting work.
 
 ### GitHub Actions Automation
 
@@ -140,7 +145,7 @@ A GitHub Actions workflow (`.github/workflows/project-automation.yml`) automatic
 **When Starting Work:**
 
 - Assign yourself to the issue
-- Automation will move to "In Progress"
+- **Manually** move status to "In Progress" (no automation for this)
 - Create a branch and reference the issue number
 
 **When Creating PR:**


### PR DESCRIPTION
## Summary

Update automation documentation to accurately reflect the workflows actually available in GitHub Projects v2.

## Problem

The original documentation described a workflow that doesn't exist:
- ❌ "Issue assigned → In Progress" (not available in GitHub Projects v2)

## Changes

### 
- Replaced hypothetical workflows with actual GitHub Projects v2 workflows
- Listed all 11 available built-in workflows
- Added clear note that "In Progress" status must be set manually
- Updated expected behavior section

### 
- Updated automation rules to match actual available workflows
- Added clarification in "When Starting Work" section
- Removed references to non-existent assignment automation

## Actual Available Workflows

**Essential (Enabled):**
1. Auto-add to project
2. Item added to project
3. Item closed
4. Pull request merged
5. Item reopened
6. Pull request linked to issue

**Optional (Also Available):**
7. Code review approved
8. Code changes requested
9. Auto-archive items
10. Auto-close issue
11. Auto-add sub-issues to project

## Testing

Verified by:
- Creating test issue #25
- Checking actual project workflows via GraphQL API
- Confirming no "Issue assigned" workflow exists in Projects v2

## Impact

- ✅ Documentation now matches reality
- ✅ Users won't expect automation that doesn't exist
- ✅ Clear instructions for manual status updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)